### PR TITLE
adding node_env for eta

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ USAGE
 
 OPTIONS
   -f, --fast  don't generate or compile, just start
+  -e=[local, dev, prod] or --env=[local, dev, prod], set the NODE_ENV, defaults to local
 ```
 
 _See code: [lib/commands/start.js](https://github.com/crossroads-education/eta-cli/blob/v1.3.25/lib/commands/start.js)_

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -8,6 +8,14 @@ export default class Start extends oclif.Command {
         fast: oclif.flags.boolean({
             char: "f",
             description: "don't generate or compile, just start"
+        }),
+        local: oclif.flags.string({
+            char: "e",
+            env: 'NODE_ENV',
+            options: ['local', 'dev', 'prod'],
+            default: 'local',
+            required: false,
+            description: "set NODE_ENV; Right now, this affects Graylog logging"
         })
     };
 

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -9,7 +9,7 @@ export default class Start extends oclif.Command {
             char: "f",
             description: "don't generate or compile, just start"
         }),
-        local: oclif.flags.string({
+        env: oclif.flags.string({
             char: "e",
             env: "NODE_ENV",
             options: ["local", "dev", "prod"],

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -11,9 +11,9 @@ export default class Start extends oclif.Command {
         }),
         local: oclif.flags.string({
             char: "e",
-            env: 'NODE_ENV',
-            options: ['local', 'dev', 'prod'],
-            default: 'local',
+            env: "NODE_ENV",
+            options: ["local", "dev", "prod"],
+            default: "local",
             required: false,
             description: "set NODE_ENV; Right now, this affects Graylog logging"
         })


### PR DESCRIPTION
Need to differentiate between environments for logging.
This pr adds `NODE_ENV` for eta-master.